### PR TITLE
Don't require the load method in every Component any more

### DIFF
--- a/src/main/java/seedu/todo/ui/MainWindow.java
+++ b/src/main/java/seedu/todo/ui/MainWindow.java
@@ -110,7 +110,7 @@ public class MainWindow extends Component {
     }
 
     protected <T extends View> T loadView(Class<T> viewClass) {
-        return UiPartLoader.loadUiPart(primaryStage, getChildrenPlaceholder(), viewClass);
+        return load(primaryStage, getChildrenPlaceholder(), viewClass);
     }
 
     /** ================ FXML COMPONENTS ================== **/

--- a/src/main/java/seedu/todo/ui/MainWindow.java
+++ b/src/main/java/seedu/todo/ui/MainWindow.java
@@ -1,8 +1,5 @@
 package seedu.todo.ui;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -10,13 +7,10 @@ import javafx.scene.Scene;
 import javafx.scene.control.MenuItem;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
-import javafx.stage.Stage;
 import seedu.todo.MainApp;
 import seedu.todo.commons.core.Config;
 import seedu.todo.commons.core.GuiSettings;
-import seedu.todo.commons.core.LogsCenter;
 import seedu.todo.commons.events.ui.ExitAppRequestEvent;
 import seedu.todo.ui.components.Component;
 import seedu.todo.ui.components.Console;
@@ -28,8 +22,6 @@ import seedu.todo.ui.views.View;
  * a menu bar and space where other JavaFX elements can be placed.
  */
 public class MainWindow extends Component {
-
-    private static final Logger logger = LogsCenter.getLogger(UiManager.class);
 
     private static final String FXML_PATH = "MainWindow.fxml";
     private static final String ICON_PATH = "/images/logo-512x512.png";
@@ -51,13 +43,7 @@ public class MainWindow extends Component {
     @FXML
     private AnchorPane headerPlaceholder;
 
-    public static MainWindow load(Stage primaryStage, Config config) {
-        MainWindow mainWindow = UiPartLoader.loadUiPart(primaryStage, null, new MainWindow());
-        mainWindow.configure(config);
-        return mainWindow;
-    }
-
-    private void configure(Config config) {
+    public void configure(Config config) {
         String appTitle = config.getAppTitle();
 
         // Configure the UI
@@ -76,13 +62,13 @@ public class MainWindow extends Component {
 
     protected void loadComponents() {
         // Load Header
-        Header header = Header.load(primaryStage, getHeaderPlaceholder());
+        Header header = UiPartLoader.loadUiPart(primaryStage, getHeaderPlaceholder(), Header.class);
         header.appTitle = MainApp.getConfig().getAppTitle();
         header.versionString = MainApp.VERSION.toString();
         header.render();
 
         // Load ConsoleInput
-        Console console = Console.load(primaryStage, getConsoleInputPlaceholder());
+        Console console = UiPartLoader.loadUiPart(primaryStage, getConsoleInputPlaceholder(), Console.class);
         console.consoleOutput = UiManager.getConsoleMessage();
         console.consoleInputValue = UiManager.getConsoleInputValue();
         console.render();
@@ -123,25 +109,8 @@ public class MainWindow extends Component {
                                (int) primaryStage.getX(), (int) primaryStage.getY());
     }
 
-    @SuppressWarnings("unchecked")
     protected <T extends View> T loadView(Class<T> viewClass) {
-        View loadedView = null;
-
-        try {
-            Method loadMethod = viewClass.getMethod("load", Stage.class, Pane.class);
-            loadedView = (View) loadMethod.invoke(null, primaryStage, getChildrenPlaceholder());
-        } catch (InvocationTargetException e) {
-            logger.severe(e.getTargetException().getMessage());
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            logger.severe(String.format("View class %s does not have a mandatory method with the method signature: \n" + 
-                                        "public static View load(Stage stage, Pane placeholder) \n" +
-                                        "This method is mandatory.", 
-                                        viewClass.getName()));
-            e.printStackTrace();
-        }
-
-        return (T) loadedView;
-
+        return UiPartLoader.loadUiPart(primaryStage, getChildrenPlaceholder(), viewClass);
     }
 
     /** ================ FXML COMPONENTS ================== **/

--- a/src/main/java/seedu/todo/ui/MainWindow.java
+++ b/src/main/java/seedu/todo/ui/MainWindow.java
@@ -18,6 +18,7 @@ import seedu.todo.commons.core.Config;
 import seedu.todo.commons.core.GuiSettings;
 import seedu.todo.commons.core.LogsCenter;
 import seedu.todo.commons.events.ui.ExitAppRequestEvent;
+import seedu.todo.ui.components.Component;
 import seedu.todo.ui.components.Console;
 import seedu.todo.ui.components.Header;
 import seedu.todo.ui.views.View;
@@ -26,7 +27,7 @@ import seedu.todo.ui.views.View;
  * The Main Window. Provides the basic application layout containing
  * a menu bar and space where other JavaFX elements can be placed.
  */
-public class MainWindow extends View {
+public class MainWindow extends Component {
 
     private static final Logger logger = LogsCenter.getLogger(UiManager.class);
 
@@ -82,8 +83,8 @@ public class MainWindow extends View {
 
         // Load ConsoleInput
         Console console = Console.load(primaryStage, getConsoleInputPlaceholder());
-        console.consoleOutput = consoleMessage;
-        console.consoleInputValue = consoleInputValue;
+        console.consoleOutput = UiManager.getConsoleMessage();
+        console.consoleInputValue = UiManager.getConsoleInputValue();
         console.render();
     }
 

--- a/src/main/java/seedu/todo/ui/UiManager.java
+++ b/src/main/java/seedu/todo/ui/UiManager.java
@@ -23,6 +23,9 @@ public class UiManager extends ComponentManager implements Ui {
     
     // Only one currentView.
     public static View currentView;
+    
+    private static String currentConsoleMessage = "";
+    private static String currentConsoleInputValue = "";
 
     private Config config;
     private MainWindow mainWindow;
@@ -89,12 +92,20 @@ public class UiManager extends ComponentManager implements Ui {
             currentView = view;
             
             // Clear console values first
-            View.consoleInputValue = "";
-            View.consoleMessage = "";
+            currentConsoleInputValue = "";
+            currentConsoleMessage = "";
             
             // Render view
             view.render();
         }
+    }
+    
+    public static String getConsoleMessage() {
+        return currentConsoleMessage;
+    }
+    
+    public static String getConsoleInputValue() {
+        return currentConsoleInputValue;
     }
     
     /**
@@ -105,7 +116,7 @@ public class UiManager extends ComponentManager implements Ui {
      */
     public static void updateConsoleMessage(String consoleMessage) {
         if (currentView != null) {
-            View.consoleMessage = consoleMessage;
+            currentConsoleMessage = consoleMessage;
             instance.mainWindow.loadComponents();
         }
     }
@@ -118,7 +129,7 @@ public class UiManager extends ComponentManager implements Ui {
      */
     public static void updateConsoleInputValue(String consoleInputValue) {
         if (currentView != null) {
-            View.consoleInputValue = consoleInputValue;
+            currentConsoleInputValue = consoleInputValue;
             instance.mainWindow.loadComponents();
         }
     }

--- a/src/main/java/seedu/todo/ui/UiManager.java
+++ b/src/main/java/seedu/todo/ui/UiManager.java
@@ -55,7 +55,8 @@ public class UiManager extends ComponentManager implements Ui {
 
         // Show main window.
         try {
-            mainWindow = MainWindow.load(primaryStage, config);
+            mainWindow = UiPartLoader.loadUiPart(primaryStage, MainWindow.class);
+            mainWindow.configure(config);
             mainWindow.render();
             mainWindow.show();
         } catch (Throwable e) {

--- a/src/main/java/seedu/todo/ui/UiManager.java
+++ b/src/main/java/seedu/todo/ui/UiManager.java
@@ -55,7 +55,7 @@ public class UiManager extends ComponentManager implements Ui {
 
         // Show main window.
         try {
-            mainWindow = UiPartLoader.loadUiPart(primaryStage, MainWindow.class);
+            mainWindow = UiPartLoader.loadUiPart(primaryStage, null, MainWindow.class);
             mainWindow.configure(config);
             mainWindow.render();
             mainWindow.show();

--- a/src/main/java/seedu/todo/ui/UiPart.java
+++ b/src/main/java/seedu/todo/ui/UiPart.java
@@ -20,10 +20,6 @@ public abstract class UiPart {
      */
     protected Stage primaryStage;
 
-    public UiPart(){
-
-    }
-
     /**
      * Raises the event via {@link EventsCenter#post(BaseEvent)}
      * @param event

--- a/src/main/java/seedu/todo/ui/UiPartLoader.java
+++ b/src/main/java/seedu/todo/ui/UiPartLoader.java
@@ -14,18 +14,32 @@ import seedu.todo.MainApp;
 public class UiPartLoader {
     private final static String FXML_FILE_FOLDER = "/ui/";
     private final static String FXML_ERROR_MESSAGE = "FXML Load Error for ";
+    private final static String INSTANTION_EXCEPTION_ERROR_MESSAGE = "Could not instantiate ";
+    
     /**
      * Loads the UiPart and returns the view controller.
      *
      * @param primaryStage The primary stage for the view.
-     * @param placeholder The placeholder where the loaded Ui Part is added.
-     * @param sampleUiPart The sample instance of the expected UiPart class.
-     * @param <T> The type of the UiPart
+     * @param placeholder  The placeholder where the loaded Ui Part is added.
+     * @param uiPartClass  The UiPart class to load.
+     * @param <T>          The type of the UiPart
      */
-    public static <T extends UiPart> T loadUiPart(Stage primaryStage, Pane placeholder, T sampleUiPart) {
+    public static <T extends UiPart> T loadUiPart(Stage primaryStage, Pane placeholder, Class<T> uiPartClass) {
         FXMLLoader loader = new FXMLLoader();
-        loader.setLocation(getFXMLResource(sampleUiPart.getFxmlPath()));
-        Node mainNode = loadLoader(loader, sampleUiPart.getFxmlPath());
+        
+        // Get FXML path
+        T instance = null;
+        try {
+            instance = uiPartClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            String errorMessage = INSTANTION_EXCEPTION_ERROR_MESSAGE + uiPartClass.getName();
+            throw new RuntimeException(errorMessage, e);
+        }
+        String fxmlPath = instance.getFxmlPath();
+        
+        // Continue with loading
+        loader.setLocation(getFXMLResource(fxmlPath));
+        Node mainNode = loadLoader(loader, fxmlPath);
 
         T controller = loader.getController();
         controller.setStage(primaryStage);
@@ -34,23 +48,16 @@ public class UiPartLoader {
         return controller;
     }
 
-    public static <T extends UiPart> T loadUiPart(Stage primaryStage, T sampleUiPart) {
-        return loadUiPart(primaryStage, null, sampleUiPart);
-    }
-
     /**
-     * Returns the ui class for a specific UI Part.
+     * Loads the UiPart and returns the view controller, without a placeholder.
+     * Should only be used for MainWindow.
      *
-     * @param seedUiPart The UiPart object to be used as the ui.
-     * @param <T> The type of the UiPart
+     * @param primaryStage The primary stage for the view.
+     * @param uiPartClass  The UiPart class to load.
+     * @param <T>          The type of the UiPart
      */
-
-    public static <T extends UiPart> T loadUiPart(T seedUiPart) {
-        FXMLLoader loader = new FXMLLoader();
-        loader.setLocation(getFXMLResource(seedUiPart.getFxmlPath()));
-        loader.setController(seedUiPart);
-        loadLoader(loader, seedUiPart.getFxmlPath());
-        return seedUiPart;
+    public static <T extends UiPart> T loadUiPart(Stage primaryStage, Class<T> uiPartClass) {
+        return loadUiPart(primaryStage, null, uiPartClass);
     }
 
 

--- a/src/main/java/seedu/todo/ui/UiPartLoader.java
+++ b/src/main/java/seedu/todo/ui/UiPartLoader.java
@@ -48,18 +48,6 @@ public class UiPartLoader {
         return controller;
     }
 
-    /**
-     * Loads the UiPart and returns the view controller, without a placeholder.
-     * Should only be used for MainWindow.
-     *
-     * @param primaryStage The primary stage for the view.
-     * @param uiPartClass  The UiPart class to load.
-     * @param <T>          The type of the UiPart
-     */
-    public static <T extends UiPart> T loadUiPart(Stage primaryStage, Class<T> uiPartClass) {
-        return loadUiPart(primaryStage, null, uiPartClass);
-    }
-
 
     private static Node loadLoader(FXMLLoader loader, String fxmlFileName) {
         try {

--- a/src/main/java/seedu/todo/ui/components/AliasItem.java
+++ b/src/main/java/seedu/todo/ui/components/AliasItem.java
@@ -1,11 +1,8 @@
 package seedu.todo.ui.components;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.commons.core.AliasDefinition;
-import seedu.todo.ui.UiPartLoader;
 
 public class AliasItem extends MultiComponent {
     
@@ -19,10 +16,6 @@ public class AliasItem extends MultiComponent {
     private Text aliasKey;
     @FXML
     private Text aliasValue;
-    
-    public static AliasItem load(Stage primaryStage, Pane placeholder) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholder, new AliasItem());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/Component.java
+++ b/src/main/java/seedu/todo/ui/components/Component.java
@@ -4,8 +4,10 @@ import java.util.logging.Logger;
 
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
 import seedu.todo.commons.core.LogsCenter;
 import seedu.todo.ui.UiPart;
+import seedu.todo.ui.UiPartLoader;
 import seedu.todo.ui.views.View;
 
 public abstract class Component extends UiPart {
@@ -14,6 +16,23 @@ public abstract class Component extends UiPart {
 
     protected Pane placeHolderPane;
     protected Pane mainNode;
+    
+    /**
+     * Loads a component into a placeholder.
+     * 
+     * <ul>
+     * <li>Gets the FXML file specified in the {@link Component}, and loads the JavaFX node.</li>
+     * <li>Loads a view controller that controls the node, and returns the view controller (ie. {@link Component}).</li>
+     * </ul>
+     * 
+     * @param primaryStage      Stage to load the component on. Typically, a Component rendering other Components should pass in primaryStage.
+     * @param placeholder       Placeholder {@code Pane} to render the component in.
+     * @param componentClass    Class of the Component to render.
+     * @return                  The Component, that controls the rendered JavaFX node.
+     */
+    public <T extends Component> T load(Stage primaryStage, Pane placeholder, Class<T> componentClass) {
+        return UiPartLoader.loadUiPart(primaryStage, placeholder, componentClass);
+    }
 
     /**
      * This method renders the View in the specified placeholder, if provided.

--- a/src/main/java/seedu/todo/ui/components/ConfigItem.java
+++ b/src/main/java/seedu/todo/ui/components/ConfigItem.java
@@ -1,11 +1,8 @@
 package seedu.todo.ui.components;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.commons.core.ConfigDefinition;
-import seedu.todo.ui.UiPartLoader;
 
 public class ConfigItem extends MultiComponent {
 
@@ -21,10 +18,6 @@ public class ConfigItem extends MultiComponent {
     private Text configName;
     @FXML
     private Text configValue;
-    
-    public static ConfigItem load(Stage primaryStage, Pane placeholder) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholder, new ConfigItem());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/Console.java
+++ b/src/main/java/seedu/todo/ui/components/Console.java
@@ -5,11 +5,8 @@ import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.Pane;
-import javafx.stage.Stage;
 import seedu.todo.commons.util.FxViewUtil;
 import seedu.todo.ui.InputHandler;
-import seedu.todo.ui.UiPartLoader;
 
 public class Console extends Component {
 
@@ -31,10 +28,6 @@ public class Console extends Component {
     @FXML
     private TextArea consoleTextArea;
 
-
-    public static Console load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new Console());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/Header.java
+++ b/src/main/java/seedu/todo/ui/components/Header.java
@@ -3,11 +3,8 @@ package seedu.todo.ui.components;
 import javafx.fxml.FXML;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.commons.util.FxViewUtil;
-import seedu.todo.ui.UiPartLoader;
 
 public class Header extends Component {
 
@@ -26,10 +23,6 @@ public class Header extends Component {
     private Text headerVersionText;
     @FXML
     private ImageView headerLogoImageView;
-
-    public static Header load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new Header());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/HelpCommandItem.java
+++ b/src/main/java/seedu/todo/ui/components/HelpCommandItem.java
@@ -1,10 +1,7 @@
 package seedu.todo.ui.components;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
-import seedu.todo.ui.UiPartLoader;
 
 public class HelpCommandItem extends MultiComponent {
 
@@ -23,9 +20,6 @@ public class HelpCommandItem extends MultiComponent {
     @FXML
     private Text commandSyntaxText;
 
-    public static HelpCommandItem load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new HelpCommandItem());
-    }
     
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/Sidebar.java
+++ b/src/main/java/seedu/todo/ui/components/Sidebar.java
@@ -3,10 +3,8 @@ package seedu.todo.ui.components;
 import java.util.List;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.models.TodoListDB;
 import seedu.todo.ui.UiPartLoader;
 
@@ -35,11 +33,7 @@ public class Sidebar extends Component {
     @FXML
     private VBox sidebarTagsPlaceholder;
 
-    public static Sidebar load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new Sidebar());
-    }
-
-    @Override
+   @Override
     public String getFxmlPath() {
         return FXML_PATH;
     }
@@ -71,7 +65,7 @@ public class Sidebar extends Component {
         String[] linkIconPaths = { TASKS_ICON_PATH, OVERDUE_ICON_PATH, EVENTS_ICON_PATH };
 
         for (int i = 0; i < linkLabels.length; i++) {
-            SidebarCounter counter = SidebarCounter.load(primaryStage, sidebarCountersPlaceholder);
+            SidebarCounter counter = UiPartLoader.loadUiPart(primaryStage, sidebarCountersPlaceholder, SidebarCounter.class);
             counter.label = linkLabels[i];
             counter.iconPath = linkIconPaths[i];
             counter.render();
@@ -82,7 +76,7 @@ public class Sidebar extends Component {
         TagListItem.reset(sidebarTagsPlaceholder);
 
         for (String tag : tags) {
-            TagListItem item = TagListItem.load(primaryStage, sidebarTagsPlaceholder);
+            TagListItem item = UiPartLoader.loadUiPart(primaryStage, sidebarTagsPlaceholder, TagListItem.class);
             item.tag = tag;
             item.render();
         }

--- a/src/main/java/seedu/todo/ui/components/Sidebar.java
+++ b/src/main/java/seedu/todo/ui/components/Sidebar.java
@@ -6,7 +6,6 @@ import javafx.fxml.FXML;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import seedu.todo.models.TodoListDB;
-import seedu.todo.ui.UiPartLoader;
 
 public class Sidebar extends Component {
 
@@ -65,7 +64,7 @@ public class Sidebar extends Component {
         String[] linkIconPaths = { TASKS_ICON_PATH, OVERDUE_ICON_PATH, EVENTS_ICON_PATH };
 
         for (int i = 0; i < linkLabels.length; i++) {
-            SidebarCounter counter = UiPartLoader.loadUiPart(primaryStage, sidebarCountersPlaceholder, SidebarCounter.class);
+            SidebarCounter counter = load(primaryStage, sidebarCountersPlaceholder, SidebarCounter.class);
             counter.label = linkLabels[i];
             counter.iconPath = linkIconPaths[i];
             counter.render();
@@ -76,7 +75,7 @@ public class Sidebar extends Component {
         TagListItem.reset(sidebarTagsPlaceholder);
 
         for (String tag : tags) {
-            TagListItem item = UiPartLoader.loadUiPart(primaryStage, sidebarTagsPlaceholder, TagListItem.class);
+            TagListItem item = load(primaryStage, sidebarTagsPlaceholder, TagListItem.class);
             item.tag = tag;
             item.render();
         }

--- a/src/main/java/seedu/todo/ui/components/SidebarCounter.java
+++ b/src/main/java/seedu/todo/ui/components/SidebarCounter.java
@@ -3,10 +3,7 @@ package seedu.todo.ui.components;
 import javafx.fxml.FXML;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
-import seedu.todo.ui.UiPartLoader;
 
 public class SidebarCounter extends MultiComponent {
 
@@ -21,10 +18,6 @@ public class SidebarCounter extends MultiComponent {
     private ImageView imageView;
     @FXML
     private Text labelText;
-
-    public static SidebarCounter load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new SidebarCounter());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/TagListItem.java
+++ b/src/main/java/seedu/todo/ui/components/TagListItem.java
@@ -1,12 +1,9 @@
 package seedu.todo.ui.components;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
-import seedu.todo.ui.UiPartLoader;
 
 public class TagListItem extends MultiComponent {
 
@@ -21,10 +18,6 @@ public class TagListItem extends MultiComponent {
     private Text labelText;
     @FXML
     private Circle labelBullet;
-
-    public static TagListItem load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new TagListItem());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/TaskList.java
+++ b/src/main/java/seedu/todo/ui/components/TaskList.java
@@ -9,9 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
-import javafx.stage.Stage;
 import seedu.todo.commons.EphemeralDB;
 import seedu.todo.commons.util.DateUtil;
 import seedu.todo.models.CalendarItem;
@@ -44,10 +42,6 @@ public class TaskList extends Component {
         loadTasks();
     }
 
-    public static TaskList load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new TaskList());
-    }
-
     private void loadTasks() {
         TaskListDateItem.reset(taskListDateItemsPlaceholder);
 
@@ -73,7 +67,7 @@ public class TaskList extends Component {
             List<Task> tasksForDate = tasksByDate.get(dateTime);
             List<Event> eventsForDate = eventsByDate.get(dateTime);
             
-            TaskListDateItem item = TaskListDateItem.load(primaryStage, taskListDateItemsPlaceholder);
+            TaskListDateItem item = UiPartLoader.loadUiPart(primaryStage, taskListDateItemsPlaceholder, TaskListDateItem.class);
             item.dateTime = dateTime;
             
             if (tasksForDate != null) {

--- a/src/main/java/seedu/todo/ui/components/TaskList.java
+++ b/src/main/java/seedu/todo/ui/components/TaskList.java
@@ -15,7 +15,6 @@ import seedu.todo.commons.util.DateUtil;
 import seedu.todo.models.CalendarItem;
 import seedu.todo.models.Event;
 import seedu.todo.models.Task;
-import seedu.todo.ui.UiPartLoader;
 
 public class TaskList extends Component {
     
@@ -67,7 +66,7 @@ public class TaskList extends Component {
             List<Task> tasksForDate = tasksByDate.get(dateTime);
             List<Event> eventsForDate = eventsByDate.get(dateTime);
             
-            TaskListDateItem item = UiPartLoader.loadUiPart(primaryStage, taskListDateItemsPlaceholder, TaskListDateItem.class);
+            TaskListDateItem item = load(primaryStage, taskListDateItemsPlaceholder, TaskListDateItem.class);
             item.dateTime = dateTime;
             
             if (tasksForDate != null) {

--- a/src/main/java/seedu/todo/ui/components/TaskListDateItem.java
+++ b/src/main/java/seedu/todo/ui/components/TaskListDateItem.java
@@ -11,7 +11,6 @@ import seedu.todo.commons.EphemeralDB;
 import seedu.todo.commons.util.DateUtil;
 import seedu.todo.models.Task;
 import seedu.todo.models.Event;
-import seedu.todo.ui.UiPartLoader;
 
 public class TaskListDateItem extends MultiComponent {
 
@@ -66,7 +65,7 @@ public class TaskListDateItem extends MultiComponent {
 
     private void loadTaskItems() {
         for (Task task : tasks) {
-            TaskListTaskItem item = UiPartLoader.loadUiPart(primaryStage, dateCalendarItemsPlaceholder, TaskListTaskItem.class);
+            TaskListTaskItem item = load(primaryStage, dateCalendarItemsPlaceholder, TaskListTaskItem.class);
 
             // Add to EphemeralDB and get the index.
             int displayIndex = ephemeralDb.addToDisplayedCalendarItems(task);
@@ -80,7 +79,7 @@ public class TaskListDateItem extends MultiComponent {
     
     private void loadEventItems() {
         for (Event event : events) {
-            TaskListEventItem item = UiPartLoader.loadUiPart(primaryStage, dateCalendarItemsPlaceholder, TaskListEventItem.class);
+            TaskListEventItem item = load(primaryStage, dateCalendarItemsPlaceholder, TaskListEventItem.class);
 
             // Add to EphemeralDB and get the index.
             int displayIndex = ephemeralDb.addToDisplayedCalendarItems(event);

--- a/src/main/java/seedu/todo/ui/components/TaskListDateItem.java
+++ b/src/main/java/seedu/todo/ui/components/TaskListDateItem.java
@@ -5,10 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.commons.EphemeralDB;
 import seedu.todo.commons.util.DateUtil;
 import seedu.todo.models.Task;
@@ -33,10 +31,6 @@ public class TaskListDateItem extends MultiComponent {
     private Text dateLabel;
     @FXML
     private VBox dateCalendarItemsPlaceholder;
-
-    public static TaskListDateItem load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new TaskListDateItem());
-    }
 
     @Override
     public String getFxmlPath() {
@@ -72,7 +66,7 @@ public class TaskListDateItem extends MultiComponent {
 
     private void loadTaskItems() {
         for (Task task : tasks) {
-            TaskListTaskItem item = TaskListTaskItem.load(primaryStage, dateCalendarItemsPlaceholder);
+            TaskListTaskItem item = UiPartLoader.loadUiPart(primaryStage, dateCalendarItemsPlaceholder, TaskListTaskItem.class);
 
             // Add to EphemeralDB and get the index.
             int displayIndex = ephemeralDb.addToDisplayedCalendarItems(task);
@@ -86,7 +80,7 @@ public class TaskListDateItem extends MultiComponent {
     
     private void loadEventItems() {
         for (Event event : events) {
-            TaskListEventItem item = TaskListEventItem.load(primaryStage, dateCalendarItemsPlaceholder);
+            TaskListEventItem item = UiPartLoader.loadUiPart(primaryStage, dateCalendarItemsPlaceholder, TaskListEventItem.class);
 
             // Add to EphemeralDB and get the index.
             int displayIndex = ephemeralDb.addToDisplayedCalendarItems(event);

--- a/src/main/java/seedu/todo/ui/components/TaskListEventItem.java
+++ b/src/main/java/seedu/todo/ui/components/TaskListEventItem.java
@@ -3,12 +3,9 @@ package seedu.todo.ui.components;
 import javafx.fxml.FXML;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.commons.util.DateUtil;
 import seedu.todo.models.Event;
-import seedu.todo.ui.UiPartLoader;
 
 public class TaskListEventItem extends MultiComponent {
 
@@ -28,10 +25,6 @@ public class TaskListEventItem extends MultiComponent {
     private Text rowIndex;
     @FXML
     private ImageView rowIconImageView;
-
-    public static TaskListEventItem load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new TaskListEventItem());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/components/TaskListTaskItem.java
+++ b/src/main/java/seedu/todo/ui/components/TaskListTaskItem.java
@@ -5,13 +5,10 @@ import java.time.LocalDateTime;
 import javafx.fxml.FXML;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.Pane;
 import javafx.scene.shape.Circle;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.commons.util.DateUtil;
 import seedu.todo.models.Task;
-import seedu.todo.ui.UiPartLoader;
 
 public class TaskListTaskItem extends MultiComponent {
 
@@ -33,10 +30,6 @@ public class TaskListTaskItem extends MultiComponent {
     private Circle taskCheckMarkCircle;
     @FXML
     private ImageView taskCheckMarkImage;
-
-    public static TaskListTaskItem load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new TaskListTaskItem());
-    }
 
     @Override
     public String getFxmlPath() {

--- a/src/main/java/seedu/todo/ui/views/AliasView.java
+++ b/src/main/java/seedu/todo/ui/views/AliasView.java
@@ -12,8 +12,6 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
-import seedu.todo.MainApp;
 import seedu.todo.commons.core.AliasDefinition;
 import seedu.todo.commons.util.FxViewUtil;
 import seedu.todo.models.TodoListDB;
@@ -35,10 +33,6 @@ public class AliasView extends View {
     private ImageView aliasImageView;
     @FXML
     private Pane aliasesPlaceholder;
-
-    public static AliasView load(Stage primaryStage, Pane placeholder) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholder, new AliasView());
-    }
 
     @Override
     public String getFxmlPath() {
@@ -74,7 +68,7 @@ public class AliasView extends View {
 
         // Load items
         for (Map.Entry<String, String> aliasPair : aliasDefinitions) {
-            AliasItem item = AliasItem.load(primaryStage, aliasesPlaceholder);
+            AliasItem item = UiPartLoader.loadUiPart(primaryStage, aliasesPlaceholder, AliasItem.class);
             item.aliasDefinition = new AliasDefinition(aliasPair.getKey(), aliasPair.getValue());
             item.render();
         }

--- a/src/main/java/seedu/todo/ui/views/AliasView.java
+++ b/src/main/java/seedu/todo/ui/views/AliasView.java
@@ -15,7 +15,6 @@ import javafx.scene.text.Text;
 import seedu.todo.commons.core.AliasDefinition;
 import seedu.todo.commons.util.FxViewUtil;
 import seedu.todo.models.TodoListDB;
-import seedu.todo.ui.UiPartLoader;
 import seedu.todo.ui.components.AliasItem;
 
 public class AliasView extends View {
@@ -68,7 +67,7 @@ public class AliasView extends View {
 
         // Load items
         for (Map.Entry<String, String> aliasPair : aliasDefinitions) {
-            AliasItem item = UiPartLoader.loadUiPart(primaryStage, aliasesPlaceholder, AliasItem.class);
+            AliasItem item = load(primaryStage, aliasesPlaceholder, AliasItem.class);
             item.aliasDefinition = new AliasDefinition(aliasPair.getKey(), aliasPair.getValue());
             item.render();
         }

--- a/src/main/java/seedu/todo/ui/views/ConfigView.java
+++ b/src/main/java/seedu/todo/ui/views/ConfigView.java
@@ -10,7 +10,6 @@ import javafx.scene.text.Text;
 import seedu.todo.MainApp;
 import seedu.todo.commons.core.ConfigDefinition;
 import seedu.todo.commons.util.FxViewUtil;
-import seedu.todo.ui.UiPartLoader;
 import seedu.todo.ui.components.ConfigItem;
 
 public class ConfigView extends View {
@@ -52,7 +51,7 @@ public class ConfigView extends View {
 
         // Load items
         for (ConfigDefinition definition : configDefinitions) {
-            ConfigItem item = UiPartLoader.loadUiPart(primaryStage, configsPlaceholder, ConfigItem.class);
+            ConfigItem item = load(primaryStage, configsPlaceholder, ConfigItem.class);
             item.configDefinition = definition;
             item.render();
         }

--- a/src/main/java/seedu/todo/ui/views/ConfigView.java
+++ b/src/main/java/seedu/todo/ui/views/ConfigView.java
@@ -7,7 +7,6 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
-import javafx.stage.Stage;
 import seedu.todo.MainApp;
 import seedu.todo.commons.core.ConfigDefinition;
 import seedu.todo.commons.util.FxViewUtil;
@@ -28,10 +27,6 @@ public class ConfigView extends View {
     private ImageView configImageView;
     @FXML
     private Pane configsPlaceholder;
-
-    public static ConfigView load(Stage primaryStage, Pane placeholder) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholder, new ConfigView());
-    }
 
     @Override
     public String getFxmlPath() {
@@ -57,7 +52,7 @@ public class ConfigView extends View {
 
         // Load items
         for (ConfigDefinition definition : configDefinitions) {
-            ConfigItem item = ConfigItem.load(primaryStage, configsPlaceholder);
+            ConfigItem item = UiPartLoader.loadUiPart(primaryStage, configsPlaceholder, ConfigItem.class);
             item.configDefinition = definition;
             item.render();
         }

--- a/src/main/java/seedu/todo/ui/views/HelpView.java
+++ b/src/main/java/seedu/todo/ui/views/HelpView.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
-import javafx.stage.Stage;
 import seedu.todo.commons.util.FxViewUtil;
 import seedu.todo.controllers.CommandDefinition;
 import seedu.todo.ui.UiPartLoader;
@@ -21,10 +20,6 @@ public class HelpView extends View {
     // FXML
     @FXML
     private Pane helpCommandsPlaceholder;
-    
-    public static HelpView load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new HelpView());
-    }
 
     @Override
     public String getFxmlPath() {
@@ -41,7 +36,7 @@ public class HelpView extends View {
         
         // Load help commands
         for (CommandDefinition command : commandDefinitions) {
-            HelpCommandItem item = HelpCommandItem.load(primaryStage, helpCommandsPlaceholder);
+            HelpCommandItem item = UiPartLoader.loadUiPart(primaryStage, helpCommandsPlaceholder, HelpCommandItem.class);
             item.commandName = command.getCommandName();
             item.commandDescription = command.getCommandDescription();
             item.commandSyntax = command.getCommandSyntax();

--- a/src/main/java/seedu/todo/ui/views/HelpView.java
+++ b/src/main/java/seedu/todo/ui/views/HelpView.java
@@ -7,7 +7,6 @@ import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
 import seedu.todo.commons.util.FxViewUtil;
 import seedu.todo.controllers.CommandDefinition;
-import seedu.todo.ui.UiPartLoader;
 import seedu.todo.ui.components.HelpCommandItem;
 
 public class HelpView extends View {
@@ -36,7 +35,7 @@ public class HelpView extends View {
         
         // Load help commands
         for (CommandDefinition command : commandDefinitions) {
-            HelpCommandItem item = UiPartLoader.loadUiPart(primaryStage, helpCommandsPlaceholder, HelpCommandItem.class);
+            HelpCommandItem item = load(primaryStage, helpCommandsPlaceholder, HelpCommandItem.class);
             item.commandName = command.getCommandName();
             item.commandDescription = command.getCommandDescription();
             item.commandSyntax = command.getCommandSyntax();

--- a/src/main/java/seedu/todo/ui/views/IndexView.java
+++ b/src/main/java/seedu/todo/ui/views/IndexView.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
-import javafx.stage.Stage;
 import seedu.todo.commons.util.FxViewUtil;
 import seedu.todo.models.Event;
 import seedu.todo.models.Task;
@@ -28,11 +27,6 @@ public class IndexView extends View {
     public List<Task> tasks = new ArrayList<>();
     public List<String> tags = new ArrayList<>();
 
-
-    public static IndexView load(Stage primaryStage, Pane placeholderPane) {
-        return UiPartLoader.loadUiPart(primaryStage, placeholderPane, new IndexView());
-    }
-
     @Override
     public String getFxmlPath() {
         return FXML_PATH;
@@ -49,12 +43,12 @@ public class IndexView extends View {
 
     private void loadComponents() {
         // Render TagList
-        Sidebar tagList = Sidebar.load(primaryStage, tagsPane);
+        Sidebar tagList = UiPartLoader.loadUiPart(primaryStage, tagsPane, Sidebar.class);
         tagList.tags = tags;
         tagList.render();
 
         // Render TaskList
-        TaskList taskList = TaskList.load(primaryStage, tasksPane);
+        TaskList taskList = UiPartLoader.loadUiPart(primaryStage, tasksPane, TaskList.class);
         taskList.tasks = tasks;
         taskList.events = events;
         taskList.render();

--- a/src/main/java/seedu/todo/ui/views/IndexView.java
+++ b/src/main/java/seedu/todo/ui/views/IndexView.java
@@ -8,7 +8,6 @@ import javafx.scene.layout.Pane;
 import seedu.todo.commons.util.FxViewUtil;
 import seedu.todo.models.Event;
 import seedu.todo.models.Task;
-import seedu.todo.ui.UiPartLoader;
 import seedu.todo.ui.components.Sidebar;
 import seedu.todo.ui.components.TaskList;
 
@@ -43,12 +42,12 @@ public class IndexView extends View {
 
     private void loadComponents() {
         // Render TagList
-        Sidebar tagList = UiPartLoader.loadUiPart(primaryStage, tagsPane, Sidebar.class);
+        Sidebar tagList = load(primaryStage, tagsPane, Sidebar.class);
         tagList.tags = tags;
         tagList.render();
 
         // Render TaskList
-        TaskList taskList = UiPartLoader.loadUiPart(primaryStage, tasksPane, TaskList.class);
+        TaskList taskList = load(primaryStage, tasksPane, TaskList.class);
         taskList.tasks = tasks;
         taskList.events = events;
         taskList.render();

--- a/src/main/java/seedu/todo/ui/views/View.java
+++ b/src/main/java/seedu/todo/ui/views/View.java
@@ -1,12 +1,6 @@
 package seedu.todo.ui.views;
-import javafx.scene.layout.Pane;
-import javafx.stage.Stage;
 import seedu.todo.ui.components.Component;
 
 public abstract class View extends Component {
-    
-    public static View load(Stage primaryStage, Pane placeholder) {
-        return null;
-    }
     
 }

--- a/src/main/java/seedu/todo/ui/views/View.java
+++ b/src/main/java/seedu/todo/ui/views/View.java
@@ -5,9 +5,6 @@ import seedu.todo.ui.components.Component;
 
 public abstract class View extends Component {
     
-    public static String consoleMessage = "";
-    public static String consoleInputValue = "";
-    
     public static View load(Stage primaryStage, Pane placeholder) {
         return null;
     }


### PR DESCRIPTION
Realised I can just pass in the `class` of the Component, so instead of doing:

```
TagList tagList = TagList.load(primaryStage, tagListPlaceholder);
```

which requires us to declare a `static` load method for every single Component, we can do:

```
TagList tagList = load(primaryStage, tagListPlaceholder, TagList.class);
```

Essentially, we can reduce all that repeated code just because of Java's inability to support static instantiation from an abstract class (or whatever else I tried but failed).

_N.B. Ignore the extra commit, I tried to do some squashing but failed or something._
