### PR TITLE
Add UpdateCommandTest cases, extract out Assert methods

### DIFF
--- a/src/test/java/seedu/todo/guitests/AddEventCommandTest.java
+++ b/src/test/java/seedu/todo/guitests/AddEventCommandTest.java
@@ -1,16 +1,12 @@
 package seedu.todo.guitests;
 
 import static org.junit.Assert.*;
-import static seedu.todo.testutil.AssertUtil.assertSameDate;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.junit.Test;
 
 import seedu.todo.commons.util.DateUtil;
-import seedu.todo.guitests.guihandles.TaskListDateItemHandle;
-import seedu.todo.guitests.guihandles.TaskListEventItemHandle;
 import seedu.todo.models.Event;
 
 public class AddEventCommandTest extends GuiTest {
@@ -27,7 +23,7 @@ public class AddEventCommandTest extends GuiTest {
         event.setName("Presentation in the Future");
         event.setStartDate(DateUtil.parseDateTime(String.format("%s 14:00:00", twoDaysFromNowIsoString)));
         event.setEndDate(DateUtil.parseDateTime(String.format("%s 19:00:00", twoDaysFromNowIsoString)));
-        assertAddSuccess(command, event);
+        assertEventNotVisibleAfterCmd(command, event);
     }
     
     @Test
@@ -45,7 +41,7 @@ public class AddEventCommandTest extends GuiTest {
         event.setName("Presentation in the Past");
         event.setStartDate(DateUtil.parseDateTime(String.format("%s 14:00:00", twoDaysBeforeNowIsoString)));
         event.setEndDate(DateUtil.parseDateTime(String.format("%s 19:00:00", twoDaysBeforeNowIsoString)));
-        assertAddNotVisible(command, event);
+        assertEventNotVisibleAfterCmd(command, event);
     }
     
     @Test
@@ -79,57 +75,6 @@ public class AddEventCommandTest extends GuiTest {
         String command = "add event \"Presentation from 2pm to 9pm";
         console.runCommand(command);
         assertEquals(console.getConsoleInputText(), command);
-    }
-
-    /**
-     * Utility method for testing if event has been successfully added to the GUI.
-     * This runs a command and checks if TaskList contains TaskListEventItem that matches
-     * the task that was just added. <br><br>
-     * 
-     * TODO: Extract out method in AddController that can return task from command,
-     *       and possibly remove the need to have eventToAdd.
-     */
-    private void assertAddSuccess(String command, Event eventToAdd) {
-        // Run the command in the console.
-        console.runCommand(command);
-        
-        // Get the event date.
-        LocalDateTime eventStartDateTime = eventToAdd.getStartDate();
-        if (eventStartDateTime == null) {
-            eventStartDateTime = DateUtil.NO_DATETIME_VALUE;
-        }
-        LocalDate eventStartDate = eventStartDateTime.toLocalDate();
-        
-        // Check TaskList if it contains a TaskListDateItem with the date of the event start date.
-        TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(eventStartDate);
-        assertSameDate(eventStartDate, dateItem);
-        
-        // Check TaskListDateItem if it contains the TaskListEventItem with the same data.
-        TaskListEventItemHandle eventItem = dateItem.getTaskListEventItem(eventToAdd.getName());
-        assertEquals(eventItem.getName(), eventToAdd.getName());
-    }
-    
-    private void assertAddNotVisible(String command, Event eventToAdd) {
-        // Run the command in the console.
-        console.runCommand(command);
-        
-        // Get the event date.
-        LocalDateTime eventStartDateTime = eventToAdd.getStartDate();
-        if (eventStartDateTime == null) {
-            eventStartDateTime = DateUtil.NO_DATETIME_VALUE;
-        }
-        LocalDate eventStartDate = eventStartDateTime.toLocalDate();
-        
-        // Gets the date item that might contain the event
-        TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(eventStartDate);
-        
-        // It's fine if there's not date item, because it's not visible.
-        if (dateItem == null) {
-            return;
-        }
-        
-        TaskListEventItemHandle eventItem = dateItem.getTaskListEventItem(eventToAdd.getName());
-        assertNull(eventItem);
     }
 
 }

--- a/src/test/java/seedu/todo/guitests/AddEventCommandTest.java
+++ b/src/test/java/seedu/todo/guitests/AddEventCommandTest.java
@@ -24,7 +24,7 @@ public class AddEventCommandTest extends GuiTest {
         event.setName("Presentation in the Future");
         event.setStartDate(DateUtil.parseDateTime(String.format("%s 14:00:00", twoDaysFromNowIsoString)));
         event.setEndDate(DateUtil.parseDateTime(String.format("%s 19:00:00", twoDaysFromNowIsoString)));
-        assertEventNotVisibleAfterCmd(command, event);
+        assertEventVisibleAfterCmd(command, event);
     }
     
     @Test

--- a/src/test/java/seedu/todo/guitests/AddTaskCommandTest.java
+++ b/src/test/java/seedu/todo/guitests/AddTaskCommandTest.java
@@ -3,15 +3,7 @@ package seedu.todo.guitests;
 import org.junit.Test;
 
 import seedu.todo.commons.util.DateUtil;
-import seedu.todo.guitests.guihandles.TaskListDateItemHandle;
-import seedu.todo.guitests.guihandles.TaskListTaskItemHandle;
 import seedu.todo.models.Task;
-
-import static seedu.todo.testutil.AssertUtil.assertSameDate;
-import static org.junit.Assert.assertEquals;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 /**
  * @@author A0139812A
@@ -24,7 +16,7 @@ public class AddTaskCommandTest extends GuiTest {
         Task task = new Task();
         task.setName("Buy milk");
         task.setCalendarDateTime(DateUtil.parseDateTime("2016-10-15 14:00:00"));
-        assertAddSuccess(command, task);
+        assertTaskVisibleAfterCmd(command, task);
     }
 
     @Test
@@ -32,34 +24,6 @@ public class AddTaskCommandTest extends GuiTest {
         String command = "add task Buy milk";
         Task task = new Task();
         task.setName("Buy milk");
-        assertAddSuccess(command, task);
-    }
-
-    /**
-     * Utility method for testing if task has been successfully added to the GUI.
-     * This runs a command and checks if TaskList contains TaskListTaskItem that matches
-     * the task that was just added. <br><br>
-     * 
-     * TODO: Extract out method in AddController that can return task from command,
-     *       and possibly remove the need to have taskToAdd.
-     */
-    private void assertAddSuccess(String command, Task taskToAdd) {
-        // Run the command in the console.
-        console.runCommand(command);
-        
-        // Get the task date.
-        LocalDateTime taskDateTime = taskToAdd.getCalendarDateTime();
-        if (taskDateTime == null) {
-            taskDateTime = DateUtil.NO_DATETIME_VALUE;
-        }
-        LocalDate taskDate = taskDateTime.toLocalDate();
-        
-        // Check TaskList if it contains a TaskListDateItem with the date.
-        TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(taskDate);
-        assertSameDate(taskDate, dateItem);
-        
-        // Check TaskListDateItem if it contains the TaskListTaskItem with the same data.
-        TaskListTaskItemHandle taskItem = dateItem.getTaskListTaskItem(taskToAdd.getName());
-        assertEquals(taskItem.getName(), taskToAdd.getName());
+        assertTaskVisibleAfterCmd(command, task);
     }
 }

--- a/src/test/java/seedu/todo/guitests/GuiTest.java
+++ b/src/test/java/seedu/todo/guitests/GuiTest.java
@@ -1,5 +1,11 @@
 package seedu.todo.guitests;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static seedu.todo.testutil.AssertUtil.assertSameDate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.After;
@@ -14,9 +20,15 @@ import javafx.stage.Stage;
 import seedu.todo.TestApp;
 import seedu.todo.commons.core.EventsCenter;
 import seedu.todo.commons.events.BaseEvent;
+import seedu.todo.commons.util.DateUtil;
 import seedu.todo.guitests.guihandles.ConsoleHandle;
 import seedu.todo.guitests.guihandles.MainGuiHandle;
+import seedu.todo.guitests.guihandles.TaskListDateItemHandle;
+import seedu.todo.guitests.guihandles.TaskListEventItemHandle;
 import seedu.todo.guitests.guihandles.TaskListHandle;
+import seedu.todo.guitests.guihandles.TaskListTaskItemHandle;
+import seedu.todo.models.Event;
+import seedu.todo.models.Task;
 import seedu.todo.models.TodoListDB;
 
 /**
@@ -87,5 +99,85 @@ public abstract class GuiTest {
     public void raise(BaseEvent e) {
         //JUnit doesn't run its test cases on the UI thread. Platform.runLater is used to post event on the UI thread.
         Platform.runLater(() -> EventsCenter.getInstance().post(e));
+    }
+    
+    /* ========= COMMON TEST METHODS ============= */
+    
+    /**
+     * Utility method for testing if task has been successfully added to the GUI.
+     * This runs a command and checks if TaskList contains TaskListTaskItem that matches
+     * the task that was just added.
+     */
+    protected void assertTaskVisibleAfterCmd(String command, Task taskToAdd) {
+        // Run the command in the console.
+        console.runCommand(command);
+        
+        // Get the task date.
+        LocalDateTime taskDateTime = taskToAdd.getCalendarDateTime();
+        if (taskDateTime == null) {
+            taskDateTime = DateUtil.NO_DATETIME_VALUE;
+        }
+        LocalDate taskDate = taskDateTime.toLocalDate();
+        
+        // Check TaskList if it contains a TaskListDateItem with the date.
+        TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(taskDate);
+        assertSameDate(taskDate, dateItem);
+        
+        // Check TaskListDateItem if it contains the TaskListTaskItem with the same data.
+        TaskListTaskItemHandle taskItem = dateItem.getTaskListTaskItem(taskToAdd.getName());
+        assertEquals(taskItem.getName(), taskToAdd.getName());
+    }
+
+    /**
+     * Utility method for testing if event has been successfully added to the GUI.
+     * This runs a command and checks if TaskList contains TaskListEventItem that matches
+     * the task that was just added.
+     * 
+     * TODO: Check event dates if they match.
+     */
+    protected void assertEventVisibleAfterCmd(String command, Event eventToAdd) {
+        // Run the command in the console.
+        console.runCommand(command);
+        
+        // Get the event date.
+        LocalDateTime eventStartDateTime = eventToAdd.getStartDate();
+        if (eventStartDateTime == null) {
+            eventStartDateTime = DateUtil.NO_DATETIME_VALUE;
+        }
+        LocalDate eventStartDate = eventStartDateTime.toLocalDate();
+        
+        // Check TaskList if it contains a TaskListDateItem with the date of the event start date.
+        TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(eventStartDate);
+        assertSameDate(eventStartDate, dateItem);
+        
+        // Check TaskListDateItem if it contains the TaskListEventItem with the same data.
+        TaskListEventItemHandle eventItem = dateItem.getTaskListEventItem(eventToAdd.getName());
+        assertEquals(eventItem.getName(), eventToAdd.getName());
+    }
+
+    /**
+     * Utility method for testing if event does not appear in the GUI after a command.
+     */
+    protected void assertEventNotVisibleAfterCmd(String command, Event eventToAdd) {
+        // Run the command in the console.
+        console.runCommand(command);
+        
+        // Get the event date.
+        LocalDateTime eventStartDateTime = eventToAdd.getStartDate();
+        if (eventStartDateTime == null) {
+            eventStartDateTime = DateUtil.NO_DATETIME_VALUE;
+        }
+        LocalDate eventStartDate = eventStartDateTime.toLocalDate();
+        
+        // Gets the date item that might contain the event
+        TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(eventStartDate);
+        
+        // It's fine if there's not date item, because it's not visible.
+        if (dateItem == null) {
+            return;
+        }
+        
+        TaskListEventItemHandle eventItem = dateItem.getTaskListEventItem(eventToAdd.getName());
+        assertNull(eventItem);
     }
 }

--- a/src/test/java/seedu/todo/guitests/GuiTest.java
+++ b/src/test/java/seedu/todo/guitests/GuiTest.java
@@ -1,9 +1,7 @@
 package seedu.todo.guitests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static seedu.todo.testutil.AssertUtil.assertSameDate;
+import static org.junit.Assert.*;
+import static seedu.todo.testutil.AssertUtil.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -108,6 +106,8 @@ public abstract class GuiTest {
      * Utility method for testing if task has been successfully added to the GUI.
      * This runs a command and checks if TaskList contains TaskListTaskItem that matches
      * the task that was just added.
+     * 
+     * Assumption: No two events can have the same name in this test.
      */
     protected void assertTaskVisibleAfterCmd(String command, Task taskToAdd) {
         // Run the command in the console.
@@ -126,13 +126,15 @@ public abstract class GuiTest {
         
         // Check TaskListDateItem if it contains the TaskListTaskItem with the same data.
         TaskListTaskItemHandle taskItem = dateItem.getTaskListTaskItem(taskToAdd.getName());
-        assertEquals(taskItem.getName(), taskToAdd.getName());
+        assertSameTaskName(taskToAdd, taskItem);
     }
 
     /**
      * Utility method for testing if event has been successfully added to the GUI.
      * This runs a command and checks if TaskList contains TaskListEventItem that matches
      * the task that was just added.
+     * 
+     * Assumption: No two events can have the same name in this test.
      * 
      * TODO: Check event dates if they match.
      */
@@ -149,17 +151,16 @@ public abstract class GuiTest {
         
         // Check TaskList if it contains a TaskListDateItem with the date of the event start date.
         TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(eventStartDate);
-        assertNotNull(dateItem);
         assertSameDate(eventStartDate, dateItem);
         
         // Check TaskListDateItem if it contains the TaskListEventItem with the same data.
         TaskListEventItemHandle eventItem = dateItem.getTaskListEventItem(eventToAdd.getName());
-        assertNotNull(eventItem);
-        assertEquals(eventItem.getName(), eventToAdd.getName());
+        assertSameEventName(eventToAdd, eventItem);
     }
 
     /**
      * Utility method for testing if event does not appear in the GUI after a command.
+     * Assumption: No two events can have the same name in this test.
      */
     protected void assertEventNotVisibleAfterCmd(String command, Event eventToAdd) {
         // Run the command in the console.
@@ -175,11 +176,12 @@ public abstract class GuiTest {
         // Gets the date item that might contain the event
         TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(eventStartDate);
         
-        // It's fine if there's not date item, because it's not visible.
+        // It's fine if there's no date item, because it's not visible.
         if (dateItem == null) {
             return;
         }
         
+        // If there's a date item, then we make sure that there isn't an event in the date item with the same name.
         TaskListEventItemHandle eventItem = dateItem.getTaskListEventItem(eventToAdd.getName());
         assertNull(eventItem);
     }

--- a/src/test/java/seedu/todo/guitests/GuiTest.java
+++ b/src/test/java/seedu/todo/guitests/GuiTest.java
@@ -2,6 +2,7 @@ package seedu.todo.guitests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static seedu.todo.testutil.AssertUtil.assertSameDate;
 
 import java.time.LocalDate;
@@ -148,10 +149,12 @@ public abstract class GuiTest {
         
         // Check TaskList if it contains a TaskListDateItem with the date of the event start date.
         TaskListDateItemHandle dateItem = taskList.getTaskListDateItem(eventStartDate);
+        assertNotNull(dateItem);
         assertSameDate(eventStartDate, dateItem);
         
         // Check TaskListDateItem if it contains the TaskListEventItem with the same data.
         TaskListEventItemHandle eventItem = dateItem.getTaskListEventItem(eventToAdd.getName());
+        assertNotNull(eventItem);
         assertEquals(eventItem.getName(), eventToAdd.getName());
     }
 

--- a/src/test/java/seedu/todo/guitests/UpdateCommandTest.java
+++ b/src/test/java/seedu/todo/guitests/UpdateCommandTest.java
@@ -1,0 +1,149 @@
+package seedu.todo.guitests;
+
+import java.time.LocalDateTime;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import seedu.todo.commons.util.DateUtil;
+import seedu.todo.models.Event;
+import seedu.todo.models.Task;
+
+public class UpdateCommandTest extends GuiTest {
+    
+    @Test
+    public void updateCommand_updateTaskName_success() {
+        // Clear first
+        console.runCommand("clear");
+        
+        // Add a task
+        console.runCommand("add Buy milk by 2016-10-15 2pm");
+        
+        // Update the task
+        String command = "update 1 name Buy bread";
+        Task task = new Task();
+        task.setName("Buy bread");
+        task.setDueDate(DateUtil.parseDateTime("2016-10-15 14:00:00"));
+        assertTaskVisibleAfterCmd(command, task);
+    }
+    
+    @Test
+    public void updateCommand_updateTaskWithDeadlineToNewDeadline_success() {
+        // Clear first
+        console.runCommand("clear");
+        
+        // Add a task
+        console.runCommand("add Buy milk by 2016-10-15 2pm");
+        
+        // Update the task
+        String command = "update 1 by today";
+        Task task = new Task();
+        task.setName("Buy milk");
+        task.setDueDate(LocalDateTime.now());
+        assertTaskVisibleAfterCmd(command, task);
+    }
+    
+    @Test
+    public void updateCommand_updateFloatingTaskToNewDeadline_success() {
+        // Clear first
+        console.runCommand("clear");
+        
+        // Add a task
+        console.runCommand("add Buy milk");
+        
+        // Update the task
+        String command = "update 1 by today";
+        Task task = new Task();
+        task.setName("Buy milk");
+        task.setDueDate(LocalDateTime.now());
+        assertTaskVisibleAfterCmd(command, task);
+    }
+
+    @Ignore
+    @Test
+    public void updateCommand_updateTaskWithDeadlineToFloatingTask() {
+        // TODO: Make this pass
+        
+        // Clear first
+        console.runCommand("clear");
+        
+        // Add a task
+        console.runCommand("add Buy milk by today");
+        
+        // Update the task
+        String command = "update 1 nodeadline";
+        Task task = new Task();
+        task.setName("Buy milk");
+        task.setDueDate(DateUtil.NO_DATETIME_VALUE);
+        assertTaskVisibleAfterCmd(command, task);
+    }
+
+    @Test
+    public void updateCommand_updateEventName_success() {
+        // Clear first
+        
+        console.runCommand("clear");
+        
+        // Get formatted string for two days from now, e.g. 17 Oct 2016
+        LocalDateTime twoDaysFromNow = LocalDateTime.now().plusDays(2);
+        String twoDaysFromNowString = DateUtil.formatDate(twoDaysFromNow);
+        String twoDaysFromNowIsoString = DateUtil.formatIsoDate(twoDaysFromNow);
+        
+        // Add a task
+        console.runCommand(String.format("add event Presentation from %s 2pm to %s 9pm", twoDaysFromNowString, twoDaysFromNowString));
+        
+        // Update the task
+        String command = "update 1 name Updated presentation";
+        Event event = new Event();
+        event.setName("Updated presentation");
+        event.setStartDate(DateUtil.parseDateTime(String.format("%s 14:00:00", twoDaysFromNowIsoString)));
+        event.setEndDate(DateUtil.parseDateTime(String.format("%s 21:00:00", twoDaysFromNowIsoString)));
+        assertEventVisibleAfterCmd(command, event);
+    }
+    
+    @Test
+    public void updateCommand_updateEventStartDate_success() {
+        // Clear first
+        
+        console.runCommand("clear");
+        
+        // Get formatted string for two days from now, e.g. 17 Oct 2016
+        LocalDateTime twoDaysFromNow = LocalDateTime.now().plusDays(2);
+        String twoDaysFromNowString = DateUtil.formatDate(twoDaysFromNow);
+        String twoDaysFromNowIsoString = DateUtil.formatIsoDate(twoDaysFromNow);
+        
+        // Add a task
+        console.runCommand(String.format("add event Presentation from %s 2pm to %s 9pm", twoDaysFromNowString, twoDaysFromNowString));
+        
+        // Update the task
+        String command = String.format("update 1 from %s 5pm", twoDaysFromNowString);
+        Event event = new Event();
+        event.setName("Updated presentation");
+        event.setStartDate(DateUtil.parseDateTime(String.format("%s 17:00:00", twoDaysFromNowIsoString)));
+        event.setEndDate(DateUtil.parseDateTime(String.format("%s 21:00:00", twoDaysFromNowIsoString)));
+        assertEventVisibleAfterCmd(command, event);
+    }
+
+    @Test
+    public void updateCommand_updateEventEndDate_success() {
+        // Clear first
+        console.runCommand("clear");
+        
+        // Get formatted string for two days from now, e.g. 17 Oct 2016
+        LocalDateTime twoDaysFromNow = LocalDateTime.now().plusDays(2);
+        String twoDaysFromNowString = DateUtil.formatDate(twoDaysFromNow);
+        String twoDaysFromNowIsoString = DateUtil.formatIsoDate(twoDaysFromNow);
+        
+        // Add a task
+        console.runCommand(String.format("add event Presentation from %s 2pm to %s 9pm", twoDaysFromNowString, twoDaysFromNowString));
+        
+        // Update the task
+        String command = String.format("update 1 to %s 5pm", twoDaysFromNowString);
+        Event event = new Event();
+        event.setName("Updated presentation");
+        event.setStartDate(DateUtil.parseDateTime(String.format("%s 14:00:00", twoDaysFromNowIsoString)));
+        event.setEndDate(DateUtil.parseDateTime(String.format("%s 17:00:00", twoDaysFromNowIsoString)));
+        assertEventVisibleAfterCmd(command, event);
+    }
+
+}

--- a/src/test/java/seedu/todo/guitests/UpdateCommandTest.java
+++ b/src/test/java/seedu/todo/guitests/UpdateCommandTest.java
@@ -81,7 +81,6 @@ public class UpdateCommandTest extends GuiTest {
     @Test
     public void updateCommand_updateEventName_success() {
         // Clear first
-        
         console.runCommand("clear");
         
         // Get formatted string for two days from now, e.g. 17 Oct 2016
@@ -104,7 +103,6 @@ public class UpdateCommandTest extends GuiTest {
     @Test
     public void updateCommand_updateEventStartDate_success() {
         // Clear first
-        
         console.runCommand("clear");
         
         // Get formatted string for two days from now, e.g. 17 Oct 2016
@@ -118,7 +116,7 @@ public class UpdateCommandTest extends GuiTest {
         // Update the task
         String command = String.format("update 1 from %s 5pm", twoDaysFromNowString);
         Event event = new Event();
-        event.setName("Updated presentation");
+        event.setName("Presentation");
         event.setStartDate(DateUtil.parseDateTime(String.format("%s 17:00:00", twoDaysFromNowIsoString)));
         event.setEndDate(DateUtil.parseDateTime(String.format("%s 21:00:00", twoDaysFromNowIsoString)));
         assertEventVisibleAfterCmd(command, event);
@@ -140,7 +138,7 @@ public class UpdateCommandTest extends GuiTest {
         // Update the task
         String command = String.format("update 1 to %s 5pm", twoDaysFromNowString);
         Event event = new Event();
-        event.setName("Updated presentation");
+        event.setName("Presentation");
         event.setStartDate(DateUtil.parseDateTime(String.format("%s 14:00:00", twoDaysFromNowIsoString)));
         event.setEndDate(DateUtil.parseDateTime(String.format("%s 17:00:00", twoDaysFromNowIsoString)));
         assertEventVisibleAfterCmd(command, event);

--- a/src/test/java/seedu/todo/testutil/AssertUtil.java
+++ b/src/test/java/seedu/todo/testutil/AssertUtil.java
@@ -3,19 +3,34 @@ package seedu.todo.testutil;
 import java.time.LocalDate;
 
 import seedu.todo.guitests.guihandles.TaskListDateItemHandle;
+import seedu.todo.guitests.guihandles.TaskListEventItemHandle;
+import seedu.todo.guitests.guihandles.TaskListTaskItemHandle;
+import seedu.todo.models.Event;
+import seedu.todo.models.Task;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * @@author A0139812A
  */
 public class AssertUtil {
-
-    public static void assertSameDate(LocalDate date, TaskListDateItemHandle dateItemHandle) {
-        assertNotNull(date);
+    
+    public static void assertSameDate(LocalDate dateToTest, TaskListDateItemHandle dateItemHandle) {
+        assertNotNull(dateToTest);
         assertNotNull(dateItemHandle.getDate());
-        assertTrue(dateItemHandle.getDate().isEqual(date));
+        assertTrue(dateItemHandle.getDate().isEqual(dateToTest));
+    }
+    
+    public static void assertSameTaskName(Task taskToTest, TaskListTaskItemHandle taskItemHandle) {
+        assertNotNull(taskToTest);
+        assertNotNull(taskItemHandle.getName());
+        assertEquals(taskItemHandle.getName(), taskToTest.getName());
+    }
+
+    public static void assertSameEventName(Event eventToTest, TaskListEventItemHandle eventItemHandle) {
+        assertNotNull(eventToTest);
+        assertNotNull(eventItemHandle.getName());
+        assertEquals(eventItemHandle.getName(), eventToTest.getName());
     }
     
 }

--- a/src/test/java/seedu/todo/testutil/AssertUtil.java
+++ b/src/test/java/seedu/todo/testutil/AssertUtil.java
@@ -17,19 +17,20 @@ public class AssertUtil {
     
     public static void assertSameDate(LocalDate dateToTest, TaskListDateItemHandle dateItemHandle) {
         assertNotNull(dateToTest);
+        assertNotNull(dateItemHandle);
         assertNotNull(dateItemHandle.getDate());
         assertTrue(dateItemHandle.getDate().isEqual(dateToTest));
     }
     
     public static void assertSameTaskName(Task taskToTest, TaskListTaskItemHandle taskItemHandle) {
         assertNotNull(taskToTest);
-        assertNotNull(taskItemHandle.getName());
+        assertNotNull(taskItemHandle);
         assertEquals(taskItemHandle.getName(), taskToTest.getName());
     }
 
     public static void assertSameEventName(Event eventToTest, TaskListEventItemHandle eventItemHandle) {
         assertNotNull(eventToTest);
-        assertNotNull(eventItemHandle.getName());
+        assertNotNull(eventItemHandle);
         assertEquals(eventItemHandle.getName(), eventToTest.getName());
     }
     


### PR DESCRIPTION
Extracted `assertTaskVisibleAfterCmd`, `assertEventVisibleAfterCmd`, `assertEventNotVisibleAfterCmd` into GuiTest to use for all testing files.

Todo: update `assertTaskVisibleAfterCmd`, `assertEventVisibleAfterCmd` to make sure that events have the same date and same time, right now it only checks date. Will do so in next PR.